### PR TITLE
Add github as download site, use it for libevent

### DIFF
--- a/packages/libevent/BUILD
+++ b/packages/libevent/BUILD
@@ -21,5 +21,5 @@ package(
 distfile(
     name='libevent-2.0.22-stable.tar.gz',
     checksum='71c2c49f0adadacfdbe6332a372c38cf9c8b7895bb73dabeaa53cdcc1d4e1fa3',
-    master_sites=sites_sourceforge('levent/libevent/libevent-2.0'),
+    master_sites={'https://github.com/libevent/libevent/releases/download/release-2.0.22-stable/'},
 )


### PR DESCRIPTION
This PR fixes download of the source tarball for libevent. 

In late 2015 the [libevent project moved from Sourceforge to Github](http://archives.seul.org/libevent/users/Jul-2015/msg00009.html) so libevent-2.0.22-stable.tar.gz is not available from Sourceforge (unsure if it was at any point). It's download URL is now

https://github.com/libevent/libevent/releases/download/release-2.0.22-stable/libevent-2.0.22-stable.tar.gz

the sha256 is unchanged.
