### PR TITLE
conding style: line length, blank lines, unused imports, dead code

### DIFF
--- a/build_packages.py
+++ b/build_packages.py
@@ -10,7 +10,9 @@ import sys
 
 from src import config
 from src import util
-from src.catalog import ArchLinuxCatalog, CygwinCatalog, DebianCatalog, FreeBSDCatalog, HomebrewCatalog, NetBSDCatalog, OpenBSDCatalog, RedHatCatalog
+from src.catalog import (ArchLinuxCatalog, CygwinCatalog, DebianCatalog,
+                         FreeBSDCatalog, HomebrewCatalog, NetBSDCatalog,
+                         OpenBSDCatalog, RedHatCatalog)
 from src.repository import Repository
 from src.version import FullVersion
 

--- a/src/builder.py
+++ b/src/builder.py
@@ -131,16 +131,6 @@ class FileHandle:
         self._builder.cmake(builddir, self._path, args)
         return FileHandle(self._builder, builddir)
 
-        # Skip directory names.
-        while True:
-            entries = os.listdir(source_directory)
-            if len(entries) != 1:
-                break
-            new_directory = os.path.join(source_directory, entries[0])
-            if not os.path.isdir(new_directory):
-                break
-            source_directory = new_directory
-
     def install(self, path='.'):
         self._builder.install(self._path, path)
 

--- a/src/package.py
+++ b/src/package.py
@@ -6,8 +6,6 @@
 import logging
 import os
 import shutil
-import stat
-import subprocess
 
 from . import config
 from . import util

--- a/src/package.py
+++ b/src/package.py
@@ -15,6 +15,7 @@ from .builder import BuildDirectory, BuildHandle, HostBuilder, TargetBuilder
 
 log = logging.getLogger(__name__)
 
+
 class HostPackage:
 
     def __init__(self, install_directory, name, version, homepage,


### PR DESCRIPTION
I started tweaking line lengths to 79 characters per python community norms as is my habit, guided by emacs flycheck and flake8. But it started to get invasive, so I wonder: do you want to aim adopt it throughout? I see you have `reformat.sh` script that's three times `--aggressive`, but it applies only to `BUILD` files.

The other edits in this PR are more straightforward.

Let me know if you prefer these commits squashed.
