### PR TITLE
Add os.pdwait() to Python.

### DIFF
--- a/packages/python/patch-pdwait
+++ b/packages/python/patch-pdwait
@@ -1,0 +1,200 @@
+diff -Nurd Modules/clinic/posixmodule.c.h Modules/clinic/posixmodule.c.h
+--- Modules/clinic/posixmodule.c.h	2017-06-09 19:05:03.924313000 +0200
++++ Modules/clinic/posixmodule.c.h	2017-06-09 19:05:11.119001000 +0200
+@@ -2986,6 +2986,47 @@
+ 
+ #endif /* (defined(HAVE_WAITID) && !defined(__APPLE__)) */
+ 
++#if defined(HAVE_PDWAIT)
++
++PyDoc_STRVAR(os_pdwait__doc__,
++"pdwait($module, fd, options, /)\n"
++"--\n"
++"\n"
++"Returns the result of waiting for a process.\n"
++"\n"
++"  fd\n"
++"    The process file descriptor to wait on.\n"
++"  options\n"
++"    Bitmask. Only the WNOHANG bit is supported.\n"
++"\n"
++"Returns either pdwait_result or None if WNOHANG is specified and the child\n"
++"process has not exited yet.");
++
++#define OS_PDWAIT_METHODDEF    \
++    {"pdwait", (PyCFunction)os_pdwait, METH_VARARGS, os_pdwait__doc__},
++
++static PyObject *
++os_pdwait_impl(PyObject *module, int fd, int options);
++
++static PyObject *
++os_pdwait(PyObject *module, PyObject *args)
++{
++    PyObject *return_value = NULL;
++    int fd;
++    int options;
++
++    if (!PyArg_ParseTuple(args, "ii:pdwait",
++        &fd, &options)) {
++        goto exit;
++    }
++    return_value = os_pdwait_impl(module, fd, options);
++
++exit:
++    return return_value;
++}
++
++#endif /* defined(HAVE_PDWAIT) */
++
+ #if defined(HAVE_WAITPID)
+ 
+ PyDoc_STRVAR(os_waitpid__doc__,
+@@ -5959,6 +6000,10 @@
+     #define OS_WAITID_METHODDEF
+ #endif /* !defined(OS_WAITID_METHODDEF) */
+ 
++#ifndef OS_PDWAIT_METHODDEF
++    #define OS_PDWAIT_METHODDEF
++#endif /* !defined(OS_PDWAIT_METHODDEF) */
++
+ #ifndef OS_WAITPID_METHODDEF
+     #define OS_WAITPID_METHODDEF
+ #endif /* !defined(OS_WAITPID_METHODDEF) */
+diff -Nurd Modules/posixmodule.c Modules/posixmodule.c
+--- Modules/posixmodule.c	2017-06-09 19:05:03.927107000 +0200
++++ Modules/posixmodule.c	2017-06-09 19:05:11.117131000 +0200
+@@ -1814,6 +1814,31 @@
+ static PyTypeObject WaitidResultType;
+ #endif
+ 
++#if defined(HAVE_PDWAIT)
++PyDoc_STRVAR(pdwait_result__doc__,
++"pdwait_result: Result from pdwait.\n\n\
++This object may be accessed either as a tuple of\n\
++  (si_signo, si_status, si_code),\n\
++or via the attributes si_signo, si_status, and so on.\n\
++\n\
++See os.pdwait for more information.");
++
++static PyStructSequence_Field pdwait_result_fields[] = {
++    {"si_signo", },
++    {"si_status",  },
++    {"si_code", },
++    {0}
++};
++
++static PyStructSequence_Desc pdwait_result_desc = {
++    "pdwait_result", /* name */
++    pdwait_result__doc__, /* doc */
++    pdwait_result_fields,
++    3
++};
++static PyTypeObject PdwaitResultType;
++#endif
++
+ static int initialized;
+ static PyTypeObject StatResultType;
+ static PyTypeObject StatVFSResultType;
+@@ -6913,7 +6938,58 @@
+ }
+ #endif /* defined(HAVE_WAITID) && !defined(__APPLE__) */
+ 
++#if defined(HAVE_PDWAIT)
++/*[clinic input]
++os.pdwait
+ 
++    fd: int
++        The process file descriptor to wait on.
++    options: int
++        Bitmask. Only the WNOHANG bit is supported.
++    /
++
++Returns the result of waiting for a process.
++
++Returns either pdwait_result or None if WNOHANG is specified and the child
++process has not exited yet.
++[clinic start generated code]*/
++
++static PyObject *
++os_pdwait_impl(PyObject *module, int fd, int options)
++/*[clinic end generated code: output=70397bf501d06955 input=4a75ad022da5b04d]*/
++{
++    PyObject *result;
++    int res;
++    int async_err = 0;
++    siginfo_t si;
++
++    do {
++        Py_BEGIN_ALLOW_THREADS
++        res = pdwait(fd, &si, options);
++        Py_END_ALLOW_THREADS
++    } while (res < 0 && errno == EINTR && !(async_err = PyErr_CheckSignals()));
++    if (res < 0)
++        return (!async_err) ? posix_error() : NULL;
++
++    if (si.si_signo == 0)
++        Py_RETURN_NONE;
++
++    result = PyStructSequence_New(&PdwaitResultType);
++    if (!result)
++        return NULL;
++
++    PyStructSequence_SET_ITEM(result, 0, PyLong_FromLong((long)(si.si_signo)));
++    PyStructSequence_SET_ITEM(result, 1, PyLong_FromLong((long)(si.si_status)));
++    PyStructSequence_SET_ITEM(result, 2, PyLong_FromLong((long)(si.si_code)));
++    if (PyErr_Occurred()) {
++        Py_DECREF(result);
++        return NULL;
++    }
++
++    return result;
++}
++#endif /* defined(HAVE_PDWAIT) */
++
+ #if defined(HAVE_WAITPID)
+ /*[clinic input]
+ os.waitpid
+@@ -12288,6 +12364,7 @@
+     OS_WAIT3_METHODDEF
+     OS_WAIT4_METHODDEF
+     OS_WAITID_METHODDEF
++    OS_PDWAIT_METHODDEF
+     OS_WAITPID_METHODDEF
+     OS_GETSID_METHODDEF
+     OS_SETSID_METHODDEF
+@@ -13020,6 +13097,11 @@
+         if (PyStructSequence_InitType2(&WaitidResultType, &waitid_result_desc) < 0)
+             return NULL;
+ #endif
++#if defined(HAVE_PDWAIT)
++        pdwait_result_desc.name = MODNAME ".pdwait_result";
++        if (PyStructSequence_InitType2(&PdwaitResultType, &pdwait_result_desc) < 0)
++            return NULL;
++#endif
+ 
+         stat_result_desc.name = "os.stat_result"; /* see issue #19209 */
+         stat_result_desc.fields[7].name = PyStructSequence_UnnamedField;
+@@ -13065,6 +13147,10 @@
+ #if defined(HAVE_WAITID) && !defined(__APPLE__)
+     Py_INCREF((PyObject*) &WaitidResultType);
+     PyModule_AddObject(m, "waitid_result", (PyObject*) &WaitidResultType);
++#endif
++#if defined(HAVE_PDWAIT)
++    Py_INCREF((PyObject*) &PdwaitResultType);
++    PyModule_AddObject(m, "pdwait_result", (PyObject*) &PdwaitResultType);
+ #endif
+     Py_INCREF((PyObject*) &StatResultType);
+     PyModule_AddObject(m, "stat_result", (PyObject*) &StatResultType);
+diff -Nurd pyconfig.h.in pyconfig.h.in
+--- pyconfig.h.in	2017-06-09 19:05:03.928070000 +0200
++++ pyconfig.h.in	2017-06-09 19:05:11.114370000 +0200
+@@ -305,6 +305,9 @@
+ /* Define to 1 if you have the `pdfork' function. */
+ #define HAVE_PDFORK 1
+ 
++/* Define to 1 if you have the `pdwait' function. */
++#define HAVE_PDWAIT 1
++
+ /* Define to 1 if you have the `forkpty' function. */
+ #undef HAVE_FORKPTY
+ 


### PR DESCRIPTION
pdwait() is a CloudABI-specific function to get the exit status of a child
process by process file descriptor. It is to pdfork() what waidpid() is to
fork(). The Python version of pdwait() takes a file descriptor and an options
parameter.

It returns None if the option WNOHANG is given and the child has not exited
yet, or a pdwait_result if it has. The pdwait_result is a Python structure
analogous to siginfo_t, which can be read as a tuple (si_signo, si_status,
si_code) or via the attributes names. The order of the tuple is the same as the
order in the waitid() tuple, to make it easier to write code compatible with
both.